### PR TITLE
Externally maintained third-party platform-specific components

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,15 @@ The content is organized into directories following the pattern `/<platform>/<li
 for example, the Libuavcan driver for STM32 can be found under `/stm32/libuavcan/`.
 Further segregation may be defined on a per-directory basis.
 
-Users are encouraged to search this repository for the code that can be used with their target platform
+All code is MIT-licensed unless a dedicated LICENSE file is provided.
+
+## See also
+
+- [107-Arduino-MCP2515](https://github.com/107-systems/107-Arduino-MCP2515) -- Arduino library for controlling the MCP2515 in order to receive/transmit CAN frames.
+- Feel free to add more references.
+
+Users are encouraged to search through this repository for code that can be used with their target platform
 and use it as a starting point or as a practical guideline in the development of a customized solution for
 the specific application.
-If nothing is found, consider checking the legacy-v0 branch: the code contained there may require heavy modification
+If nothing is found, consider checking the `legacy-v0` branch: the code contained there may require heavy modification
 but it might still be useful.
-
-All code is MIT-licensed unless a dedicated LICENSE file is provided.


### PR DESCRIPTION
This is a follow-up to https://github.com/UAVCAN/platform_specific_components/issues/15#issuecomment-702126881.

We need a third opinion so I would like to summon @thirtytwobits and let him choose how do we handle the inclusion of externally maintained third-party drivers:

- link from README like I am proposing here in this PR **[merge this PR if you choose this option]**
- use git-subtree **[reject this PR if you choose this option]**

Thanks.

Fixes #15