### PR TITLE
socketcan - added loopback and kernel time-stamping

### DIFF
--- a/socketcan/libcanard/src/socketcan.c
+++ b/socketcan/libcanard/src/socketcan.c
@@ -179,7 +179,7 @@ int16_t socketcanPop(const SocketCANFD       fd,
     const int16_t poll_result = doPoll(fd, POLLIN, timeout_usec);
     if (poll_result > 0)
     {
-        // Initialize the message header scatter/gather array.
+        // Initialize the message header scatter/gather array. It is to hold a single CAN FD frame struct.
         // We use the CAN FD struct regardless of whether the CAN FD socket option is set.
         // Per the user manual, this is acceptable because they are binary compatible.
         struct canfd_frame sockcan_frame = {0};  // CAN FD frame storage.
@@ -191,7 +191,7 @@ int16_t socketcanPop(const SocketCANFD       fd,
         };
 
         // Determine the size of the ancillary data and zero-initialize the buffer for it.
-        // We require space for both the receive message header and the time stamp.
+        // We require space for both the receive message header (implied in CMSG_SPACE) and the time stamp.
         // The ancillary data buffer is wrapped in a union to ensure it is suitably aligned.
         // See the cmsg(3) man page (release 5.08 dated 2020-06-09, or later) for details.
         union
@@ -259,7 +259,7 @@ int16_t socketcanPop(const SocketCANFD       fd,
         }
 
         (void) memset(out_frame, 0, sizeof(CanardFrame));
-        out_frame->timestamp_usec  = (CanardMicrosecond)(((uint64_t) tv.tv_sec * MEGA) + tv.tv_usec);
+        out_frame->timestamp_usec  = (CanardMicrosecond)(((uint64_t) tv.tv_sec * MEGA) + (uint64_t) tv.tv_usec);
         out_frame->extended_can_id = sockcan_frame.can_id & CAN_EFF_MASK;
         out_frame->payload_size    = sockcan_frame.len;
         out_frame->payload         = payload_buffer;

--- a/socketcan/libcanard/src/socketcan.c
+++ b/socketcan/libcanard/src/socketcan.c
@@ -239,7 +239,7 @@ int16_t socketcanPop(const SocketCANFD       fd,
             return 0;  // Not an extended data frame -- drop silently and return early.
         }
 
-        const bool loopback_frame = (msg.msg_flags & (int) MSG_CONFIRM) != 0;  // NOLINT
+        const bool loopback_frame = ((uint32_t) msg.msg_flags & (uint32_t) MSG_CONFIRM) != 0;  // NOLINT
         if (loopback == NULL && loopback_frame)
         {
             free(control);

--- a/socketcan/libcanard/src/socketcan.c
+++ b/socketcan/libcanard/src/socketcan.c
@@ -266,7 +266,7 @@ int16_t socketcanPop(const SocketCANFD       fd,
         {
             assert(0);
             free(control);
-            return -1;
+            return -EIO;
         }
 
         (void) memset(out_frame, 0, sizeof(CanardFrame));

--- a/socketcan/libcanard/src/socketcan.h
+++ b/socketcan/libcanard/src/socketcan.h
@@ -12,6 +12,15 @@
 /// To integrate the library into your application, just copy-paste the c/h files into your project tree.
 ///
 /// --------------------------------------------------------------------------------------------------------------------
+/// Changelog
+///
+/// v0.1 - Added loop-back functionality.
+///        API change in socketcanPop(): loopback flag added.
+///      - Changed to kernel-based time-stamping for received frames for improved accuracy.
+///        API change in socketcanPop(): time stamp clock source is now CLOCK_REALTIME, vs CLOCK_TAI before.
+///
+/// v0.0 - Initial release
+/// --------------------------------------------------------------------------------------------------------------------
 ///
 /// This software is distributed under the terms of the MIT License.
 /// Copyright (c) 2020 UAVCAN Development Team.

--- a/socketcan/libcanard/src/socketcan.h
+++ b/socketcan/libcanard/src/socketcan.h
@@ -36,13 +36,6 @@ typedef int SocketCANFD;
 /// On failure, a negated errno is returned.
 /// To discard the socket just call close() on it; no additional de-initialization activities are required.
 /// The argument can_fd enables support for CAN FD frames.
-///
-/// If you need the outgoing frames to be looped back, set option CAN_RAW_RECV_OWN_MSGS on the returned socket handle:
-///   const int on = 1;
-///   int err = setsockopt(s, SOL_CAN_RAW, CAN_RAW_RECV_OWN_MSGS, &on, sizeof(on));
-/// It is currently not possible to distinguish loopback frames from true RX frames. If you need that,
-/// consider using recvmsg(..) instead of this wrapper as shown in the following example:
-/// https://github.com/UAVCAN/platform_specific_components/blob/4745ef59f57b7e1c34705b127ea8c7a35e3874c1/linux/libuavcan/include/uavcan_linux/socketcan.hpp#L210-L270
 SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd);
 
 /// Enqueue a new extended CAN data frame for transmission.
@@ -55,7 +48,7 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
 /// If the received frame is not an extended-ID data frame, it will be dropped and the function will return early.
 /// The payload pointer of the returned frame will point to the payload_buffer. It can be a stack-allocated array.
 /// The payload_buffer_size shall be large enough (64 bytes is enough for CAN FD), otherwise an error is returned.
-/// The timestamp of the received frame will be set to the CLOCK_TAI sampled near the moment of its arrival.
+/// The timestamp of the received frame will be set to the kernel CLOCK_TAI sampled near the moment of its arrival.
 /// The loopback flag pointer is used to both indicate and control behavior when a looped-back message is received.
 /// If the flag pointer is NULL, loopback frames are silently dropped; if not NULL, they are accepted and indicated
 /// using this flag.

--- a/socketcan/libcanard/src/socketcan.h
+++ b/socketcan/libcanard/src/socketcan.h
@@ -48,7 +48,7 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
 /// If the received frame is not an extended-ID data frame, it will be dropped and the function will return early.
 /// The payload pointer of the returned frame will point to the payload_buffer. It can be a stack-allocated array.
 /// The payload_buffer_size shall be large enough (64 bytes is enough for CAN FD), otherwise an error is returned.
-/// The timestamp of the received frame will be set to the kernel CLOCK_TAI sampled near the moment of its arrival.
+/// The received frame timestamp will be set to CLOCK_REALTIME by the kernel, sampled near the moment of its arrival.
 /// The loopback flag pointer is used to both indicate and control behavior when a looped-back message is received.
 /// If the flag pointer is NULL, loopback frames are silently dropped; if not NULL, they are accepted and indicated
 /// using this flag.

--- a/socketcan/libcanard/src/socketcan.h
+++ b/socketcan/libcanard/src/socketcan.h
@@ -14,12 +14,12 @@
 /// --------------------------------------------------------------------------------------------------------------------
 /// Changelog
 ///
-/// v0.1 - Added loop-back functionality.
+/// v2.0 - Added loop-back functionality.
 ///        API change in socketcanPop(): loopback flag added.
 ///      - Changed to kernel-based time-stamping for received frames for improved accuracy.
 ///        API change in socketcanPop(): time stamp clock source is now CLOCK_REALTIME, vs CLOCK_TAI before.
 ///
-/// v0.0 - Initial release
+/// v1.0 - Initial release
 /// --------------------------------------------------------------------------------------------------------------------
 ///
 /// This software is distributed under the terms of the MIT License.

--- a/socketcan/libcanard/src/socketcan.h
+++ b/socketcan/libcanard/src/socketcan.h
@@ -56,6 +56,9 @@ int16_t socketcanPush(const SocketCANFD fd, const CanardFrame* const frame, cons
 /// The payload pointer of the returned frame will point to the payload_buffer. It can be a stack-allocated array.
 /// The payload_buffer_size shall be large enough (64 bytes is enough for CAN FD), otherwise an error is returned.
 /// The timestamp of the received frame will be set to the CLOCK_TAI sampled near the moment of its arrival.
+/// The loopback flag pointer is used to both indicate and control behavior when a looped-back message is received.
+/// If the flag pointer is NULL, loopback frames are silently dropped; if not NULL, they are accepted and indicated
+/// using this flag.
 /// The function will block until a frame is received or until the timeout is expired. It may return early.
 /// Zero timeout makes the operation non-blocking.
 /// Returns 1 on success, 0 on timeout, negated errno on error.
@@ -63,7 +66,8 @@ int16_t socketcanPop(const SocketCANFD       fd,
                      CanardFrame* const      out_frame,
                      const size_t            payload_buffer_size,
                      void* const             payload_buffer,
-                     const CanardMicrosecond timeout_usec);
+                     const CanardMicrosecond timeout_usec,
+                     bool* const             loopback);
 
 /// The configuration of a single extended 29-bit data frame acceptance filter.
 /// Bits above the 29-th shall be cleared.

--- a/socketcan/libcanard/test/test_io.cpp
+++ b/socketcan/libcanard/test/test_io.cpp
@@ -29,7 +29,7 @@ TEST_CASE("IO-Classic")  // Catch2 does not support parametrized tests yet.
 
     char buf[255]{};
     fr = {};
-    REQUIRE(1 == socketcanPop(sb, &fr, sizeof(buf), buf, 1000));
+    REQUIRE(1 == socketcanPop(sb, &fr, sizeof(buf), buf, 1000, nullptr));
     REQUIRE(fr.timestamp_usec > 0);
     REQUIRE(fr.extended_can_id == 0x1234U);
     REQUIRE(fr.payload_size == 6);
@@ -37,17 +37,18 @@ TEST_CASE("IO-Classic")  // Catch2 does not support parametrized tests yet.
     auto old_ts = fr.timestamp_usec;
 
     fr = {};
-    REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));  // Loopback frame.
+    REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));  // Received actual frame.
     REQUIRE(fr.timestamp_usec > 0);
     REQUIRE(fr.timestamp_usec >= old_ts);
     REQUIRE(fr.extended_can_id == 0x4321U);
     REQUIRE(fr.payload_size == 7);
     REQUIRE(0 == std::memcmp(fr.payload, "World!", 7));
 
-    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 0));
-    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000));
-    REQUIRE(-EINVAL == socketcanPop(sa, &fr, 0, nullptr, 1000));
-    REQUIRE(-EINVAL == socketcanPop(sa, nullptr, sizeof(buf), buf, 1000));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 0, nullptr));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));
+    REQUIRE(-EINVAL == socketcanPop(sa, &fr, 0, nullptr, 1000, nullptr));
+    REQUIRE(-EINVAL == socketcanPop(sa, nullptr, sizeof(buf), buf, 1000, nullptr));
 
     REQUIRE(-EINVAL == socketcanPush(sa, nullptr, 1'000'000));
 
@@ -85,7 +86,7 @@ TEST_CASE("IO-FD")
 
     char buf[255]{};
     fr = {};
-    REQUIRE(1 == socketcanPop(sb, &fr, sizeof(buf), buf, 1000));
+    REQUIRE(1 == socketcanPop(sb, &fr, sizeof(buf), buf, 1000, nullptr));
     REQUIRE(fr.timestamp_usec > 0);
     REQUIRE(fr.extended_can_id == 0x1234U);
     REQUIRE(fr.payload_size == 13);
@@ -93,19 +94,62 @@ TEST_CASE("IO-FD")
     auto old_ts = fr.timestamp_usec;
 
     fr = {};
-    REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));  // Loopback frame.
+    REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));  // Received actual frame.
     REQUIRE(fr.timestamp_usec > 0);
     REQUIRE(fr.timestamp_usec >= old_ts);
     REQUIRE(fr.extended_can_id == 0x4321U);
     REQUIRE(fr.payload_size == 10);
     REQUIRE(0 == std::memcmp(fr.payload, "0123456789", 10));
 
-    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 0));
-    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000));
-    REQUIRE(-EINVAL == socketcanPop(sa, &fr, 0, nullptr, 1000));
-    REQUIRE(-EINVAL == socketcanPop(sa, nullptr, sizeof(buf), buf, 1000));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 0, nullptr));
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));
+    REQUIRE(-EINVAL == socketcanPop(sa, &fr, 0, nullptr, 1000, nullptr));
+    REQUIRE(-EINVAL == socketcanPop(sa, nullptr, sizeof(buf), buf, 1000, nullptr));
 
     REQUIRE(-EINVAL == socketcanPush(sa, nullptr, 1'000'000));
+
+    ::close(sa);
+    ::close(sb);
+}
+
+TEST_CASE("IO-FD-Loopback")
+{
+    const char* const iface_name = "vcan0";
+
+    const auto sa = socketcanOpen(iface_name, true);
+    const auto sb = socketcanOpen(iface_name, true);
+    REQUIRE(sa >= 0);
+    REQUIRE(sb >= 0);
+
+    CanardFrame fr{};
+    fr.extended_can_id = 0x1234U;
+    fr.payload_size    = 13;
+    fr.payload         = "Hello World!";
+    REQUIRE(1 == socketcanPush(sa, &fr, 1'000'000));  // Send frame on sa.
+
+    bool loopback = true;
+    char buf[255]{};
+    fr = {};
+    REQUIRE(1 == socketcanPop(sb, &fr, sizeof(buf), buf, 1000, &loopback));  // Receive actual frame on sb.
+    REQUIRE(loopback == false);
+    REQUIRE(fr.timestamp_usec > 0);
+    REQUIRE(fr.extended_can_id == 0x1234U);
+    REQUIRE(fr.payload_size == 13);
+    REQUIRE(0 == std::memcmp(fr.payload, "Hello World!", 13));
+    auto old_ts = fr.timestamp_usec;
+
+    fr = {};
+    REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, &loopback));  // Receive loopback frame on sa.
+    REQUIRE(loopback == true);
+    REQUIRE(fr.timestamp_usec > 0);
+    REQUIRE(fr.timestamp_usec >= old_ts); // TODO: time relation still sensible? Appears to be equal...
+    REQUIRE(fr.extended_can_id == 0x1234U);
+    REQUIRE(fr.payload_size == 13);
+    REQUIRE(0 == std::memcmp(fr.payload, "Hello World!", 13));
+
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 0, nullptr));     // No more frames.
+    REQUIRE(0 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, nullptr));  // No more frames.
 
     ::close(sa);
     ::close(sb);

--- a/socketcan/libcanard/test/test_io.cpp
+++ b/socketcan/libcanard/test/test_io.cpp
@@ -143,7 +143,7 @@ TEST_CASE("IO-FD-Loopback")
     REQUIRE(1 == socketcanPop(sa, &fr, sizeof(buf), buf, 1000, &loopback));  // Receive loopback frame on sa.
     REQUIRE(loopback == true);
     REQUIRE(fr.timestamp_usec > 0);
-    REQUIRE(fr.timestamp_usec >= old_ts); // TODO: time relation still sensible? Appears to be equal...
+    REQUIRE(fr.timestamp_usec >= old_ts);
     REQUIRE(fr.extended_can_id == 0x1234U);
     REQUIRE(fr.payload_size == 13);
     REQUIRE(0 == std::memcmp(fr.payload, "Hello World!", 13));


### PR DESCRIPTION
Hello Pavel,

As discussed, here are the changes. There are a few TODO (questions) left for you. Thus far, this seems to work well. 

While I was as it, I've also ported the kernel timestamping code from uavcan to this driver, to resolve the pre-existing todo and anticipate the timing requirements for my application.

As per usual, all comments welcome.

Best regards,
Tom