### PR TITLE
BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK auto retrieve

### DIFF
--- a/stm32/libcanard/bxcan/src/bxcan.c
+++ b/stm32/libcanard/bxcan/src/bxcan.c
@@ -102,7 +102,8 @@ static bool waitMSRINAKBitStateChange(volatile const BxCANType* const bxcan_base
         // The counter variable is declared volatile to prevent the compiler from optimizing it away.
         volatile size_t nticks = BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK / 7000U;
         while (--nticks)
-        {}
+        {
+        }
     }
 
     return out_status;

--- a/stm32/libcanard/bxcan/src/bxcan.c
+++ b/stm32/libcanard/bxcan/src/bxcan.c
@@ -18,7 +18,7 @@
 /// If using official HAL from ST, set to global variable SystemCoreClock
 #ifdef USE_HAL_DRIVER
 extern uint32_t SystemCoreClock;
-#define BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK SystemCoreClock
+#    define BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK SystemCoreClock
 #else
 #    if !defined(BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK)
 #        error "Please set BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK to the current system core clock."
@@ -102,8 +102,7 @@ static bool waitMSRINAKBitStateChange(volatile const BxCANType* const bxcan_base
         // The counter variable is declared volatile to prevent the compiler from optimizing it away.
         volatile size_t nticks = BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK / 7000U;
         while (--nticks)
-        {
-        }
+        {}
     }
 
     return out_status;

--- a/stm32/libcanard/bxcan/src/bxcan.c
+++ b/stm32/libcanard/bxcan/src/bxcan.c
@@ -16,7 +16,7 @@
 /// Configure the system core clock frequency in Hz.
 /// Only used by the busy wait in waitMSRINAKBitStateChange().
 /// If using official HAL from ST, set to global variable SystemCoreClock
-#ifdef USE_HAL_DRIVER
+#if defined(USE_HAL_DRIVER) && USE_HAL_DRIVER
 extern uint32_t SystemCoreClock;
 #    define BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK SystemCoreClock
 #else
@@ -24,6 +24,7 @@ extern uint32_t SystemCoreClock;
 #        error "Please set BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK to the current system core clock."
 #    endif
 #endif
+
 /// By default, this macro resolves to the standard assert(). The user can redefine this if necessary.
 /// To disable assertion checks completely, make it expand into `(void)(0)`.
 #ifndef BXCAN_ASSERT

--- a/stm32/libcanard/bxcan/src/bxcan.c
+++ b/stm32/libcanard/bxcan/src/bxcan.c
@@ -15,10 +15,15 @@
 
 /// Configure the system core clock frequency in Hz.
 /// Only used by the busy wait in waitMSRINAKBitStateChange().
-#if !defined(BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK)
-#    error "Please set BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK to the current system core clock."
+/// If using official HAL from ST, set to global variable SystemCoreClock
+#ifdef USE_HAL_DRIVER
+extern uint32_t SystemCoreClock;
+#define BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK SystemCoreClock
+#else
+#    if !defined(BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK)
+#        error "Please set BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK to the current system core clock."
+#    endif
 #endif
-
 /// By default, this macro resolves to the standard assert(). The user can redefine this if necessary.
 /// To disable assertion checks completely, make it expand into `(void)(0)`.
 #ifndef BXCAN_ASSERT


### PR DESCRIPTION
For STM32: added possibility to autonomously set `BXCAN_BUSYWAIT_DELAY_SYSTEM_CORE_CLOCK` to global variable `SystemCoreClock` when using ST's HAL.